### PR TITLE
Add cursor indicator for Name and Description fields in edit mode (fixes #28)

### DIFF
--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -251,7 +251,7 @@ fn render_records(frame: &mut Frame, area: Rect, app: &AppState) {
                     crate::ui::EditField::Name => {
                         // Add cursor indicator to show user is in edit mode
                         let text_with_cursor = format!("{}▏", app.input_buffer);
-                        
+
                         // Extract and display ticket badge if present and config exists
                         let display = if app.config.has_integrations() {
                             if crate::integrations::extract_ticket_from_name(&app.input_buffer)
@@ -274,7 +274,7 @@ fn render_records(frame: &mut Frame, area: Rect, app: &AppState) {
                     crate::ui::EditField::Description => {
                         // Add cursor indicator to show user is in edit mode
                         let description_with_cursor = format!("{}▏", app.input_buffer);
-                        
+
                         // Extract and display ticket badge if present and config exists
                         let display = if app.config.has_integrations() {
                             if crate::integrations::extract_ticket_from_name(&record.name).is_some()


### PR DESCRIPTION
https://github.com/user-attachments/assets/6fda31a5-b16b-4361-901a-4dc1f8ffb3fa

- Display a thin cursor (▏) at the end of text when editing Name or Description fields
- Provides visual feedback to users that they are in edit mode and can type
- Time fields already had cursor indicators showing which digit is being edited
- Fixes #28



