### PR TITLE
Fix Windows URL opening with query parameters (v2)

### DIFF
--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -1072,10 +1072,12 @@ fn open_url_in_browser(url: &str) -> std::io::Result<()> {
 
     #[cfg(target_os = "windows")]
     {
-        // Windows cmd.exe treats & as a command separator, so we must quote the URL.
-        // Using empty "" as first arg to `start` sets window title, then quoted URL.
+        // Windows cmd.exe treats & as a command separator.
+        // We use raw_arg to pass the complete command string with proper quoting.
+        // Format: cmd /C start "" "url" - empty quotes for title, quoted URL.
+        use std::os::windows::process::CommandExt;
         std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
+            .raw_arg(format!("/C start \"\" \"{}\"", url))
             .spawn()?;
     }
 


### PR DESCRIPTION
## Summary
- Fixes issue #42 where browser opening didn't work with URLs containing `&` characters on Windows
- The previous fix (PR #44) using `args()` didn't work because `cmd.exe` still interprets `&` as a command separator

## Root Cause
When using `std::process::Command::args()`, Rust quotes the arguments, but `cmd /C` concatenates them into a single command string where `&` is still treated as a command separator.

User error output showed:
```
'f' is not recognized as an internal or external command
'bugID' is not recognized as an internal or external command
```

## Fix
Use `raw_arg()` from `std::os::windows::process::CommandExt` to pass the complete command string with proper quoting:
```rust
.raw_arg(format!("/C start \"\" \"{}\"", url))
```

This ensures the URL is wrapped in quotes that `cmd.exe` will respect.

Related to #42