### PR TITLE
Add support for `cargo-binstall`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,12 @@ clap = { version = "4.4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.8"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target-family }-x86_64{archive-suffix}"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-macos-x86_64{archive-suffix}"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-macos-aarch64{archive-suffix}"


### PR DESCRIPTION
With this PR, `cargo-binstall` can correctly identify binaries and install them.

I have tested for these supported targets:
- `x86_64-unknown-linux-musl`
- `x86_64-unknown-linux-gnu`
- `x86_64-apple-darwin`
- `aarch64-apple-darwin`
- `x86_64-pc-windows-gnu`