### PR TITLE
Fix flaky test that fails near midnight

### DIFF
--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -654,10 +654,14 @@ mod tests {
         // The record should have updated end time (not still 10:00)
         let updated_record = updated_day_data.work_records.get(&1).unwrap();
         assert_eq!(updated_record.name, "Existing Task");
-        // End time should be close to now (within a few minutes)
+        // End time should have been updated from the original 10:00
+        // We verify it changed, rather than checking against wall clock time
+        // (which is flaky due to timezone differences and midnight edge cases)
         assert!(
-            updated_record.end.hour >= now.hour()
-                || (updated_record.end.hour == 0 && now.hour() == 23)
-        ); // Handle day boundary
+            updated_record.end.hour != 10 || updated_record.end.minute != 0,
+            "End time should have been updated from original 10:00, got {:02}:{:02}",
+            updated_record.end.hour,
+            updated_record.end.minute
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Fixed `test_stop_updates_existing_record` which was failing for AUR users installing near midnight
- Changed assertion from comparing against wall clock time to verifying the end time was updated from the original value (10:00)

## Problem
The test was comparing `updated_record.end.hour >= now.hour()` which fails when:
- Test starts at 23:59 and finishes at 00:00 (hour rollover)
- Timezone differences between UTC and local time

This caused AUR builds to fail during `check()` phase, blocking installation for users.

## Solution
Instead of comparing against wall clock time, verify the end time changed from the original 10:00 value. This is timezone-agnostic and midnight-safe.

Fixes #49