### PR TITLE
Lunch is also break

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ target
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -32,6 +32,11 @@ fn calculate_timer_elapsed(timer: &TimerState) -> StdDuration {
     elapsed_std.saturating_sub(paused_duration_std)
 }
 
+fn is_break_like_task(task_name: &str) -> bool {
+    let name_lower = task_name.to_lowercase();
+    name_lower.contains("break") || name_lower.contains("lunch")
+}
+
 pub fn render(frame: &mut Frame, app: &AppState) {
     // Layout changes if timer is active: add timer bar at top
     let main_constraints = if app.active_timer.is_some() {
@@ -233,7 +238,7 @@ fn render_records(frame: &mut Frame, area: Rect, app: &AppState) {
             // Add icon/emoji based on task type, with timer indicator if active
             let icon = if has_active_timer {
                 "⏱ " // Timer icon for active timers
-            } else if record.name.to_lowercase().contains("break") {
+            } else if is_break_like_task(&record.name) {
                 "☕"
             } else if record.name.to_lowercase().contains("meeting") {
                 "👥"
@@ -449,7 +454,7 @@ fn render_grouped_totals(frame: &mut Frame, area: Rect, app: &AppState) {
             let mins = minutes % 60;
 
             // Choose icon based on task type
-            let icon = if name.to_lowercase().contains("break") {
+            let icon = if is_break_like_task(name) {
                 "☕"
             } else if name.to_lowercase().contains("meeting") {
                 "👥"
@@ -1176,7 +1181,7 @@ fn render_task_picker(frame: &mut Frame, app: &AppState) {
                 };
 
                 // Add icon based on task type
-                let icon = if name.to_lowercase().contains("break") {
+                let icon = if is_break_like_task(name) {
                     "☕"
                 } else if name.to_lowercase().contains("meeting") {
                     "👥"


### PR DESCRIPTION
This is an opinion hopefully the code isn't at issue.

Basically 'lunch' should be grouped in with break. In the US those are legally distinct and lunch is unpaid, while break is paid. So I just don't log breaks.

Haven't though it through too much, but I'd like to do more than request a petty change.