### PR TITLE
Remember recent tasks in picker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ fn handle_key_event(app: &mut AppState, key: KeyEvent, storage: &mut storage::St
             KeyCode::Left | KeyCode::Char('h') => app.move_field_left(),
             KeyCode::Right | KeyCode::Char('l') => app.move_field_right(),
             KeyCode::Char('i') => app.enter_edit_mode(),
-            KeyCode::Char('c') => app.change_task_name(),
+            KeyCode::Char('c') => change_task_name(app, storage),
             KeyCode::Char('n') => {
                 app.add_new_record();
                 let _ = storage.save(&app.day_data);
@@ -292,6 +292,17 @@ fn is_enter_key(key: KeyEvent) -> bool {
         && matches!(key.code, KeyCode::Char('j') | KeyCode::Char('m')))
 }
 
+fn change_task_name(app: &mut AppState, storage: &storage::StorageManager) {
+    let task_names = storage
+        .recent_task_names(app.current_date, 3)
+        .unwrap_or_else(|err| {
+            app.last_error_message = Some(format!("Failed to load recent tasks: {}", err));
+            app.get_unique_task_names()
+        });
+
+    app.change_task_name(task_names);
+}
+
 fn execute_command_action(
     app: &mut AppState,
     action: ui::app_state::CommandAction,
@@ -305,7 +316,7 @@ fn execute_command_action(
         CommandAction::MoveLeft => app.move_field_left(),
         CommandAction::MoveRight => app.move_field_right(),
         CommandAction::Edit => app.enter_edit_mode(),
-        CommandAction::Change => app.change_task_name(),
+        CommandAction::Change => change_task_name(app, storage),
         CommandAction::New => {
             app.add_new_record();
             let _ = storage.save(&app.day_data);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,7 +2,7 @@ use crate::models::{DayData, TimePoint, WorkRecord};
 use crate::timer::{TimerState, TimerStatus};
 use anyhow::{Context, Result, anyhow};
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration as StdDuration, SystemTime};
@@ -154,6 +154,10 @@ impl StorageManager {
         self.file_modified_times.get(date).copied().flatten()
     }
 
+    pub fn recent_task_names(&self, date: Date, days_back: u8) -> Result<Vec<String>> {
+        self.storage.recent_task_names(date, days_back)
+    }
+
     #[allow(dead_code)]
     pub fn save_active_timer(&self, timer: &TimerState) -> Result<()> {
         self.storage.save_active_timer(timer)
@@ -298,6 +302,10 @@ impl Storage {
 
     pub fn list_dates_with_records(&self) -> Result<Vec<Date>> {
         self.repository.list_dates_with_records()
+    }
+
+    pub fn recent_task_names(&self, date: Date, days_back: u8) -> Result<Vec<String>> {
+        self.repository.recent_task_names(date, days_back)
     }
 
     #[cfg(test)]
@@ -766,6 +774,43 @@ impl SqliteRepository {
         }
 
         Ok(dates)
+    }
+
+    fn recent_task_names(&self, date: Date, days_back: u8) -> Result<Vec<String>> {
+        let start_date = (0..days_back).try_fold(date, |date, _| {
+            date.previous_day()
+                .context("Failed to calculate recent task date range")
+        })?;
+
+        let conn = self.open_connection()?;
+        let mut stmt = conn
+            .prepare(
+                "
+                SELECT name
+                FROM work_records
+                WHERE date >= ?1 AND date <= ?2
+                ORDER BY date DESC, id DESC
+                ",
+            )
+            .context("Failed to prepare recent task names query")?;
+
+        let mut rows = stmt
+            .query(params![format_date(start_date), format_date(date)])
+            .context("Failed to query recent task names")?;
+
+        let mut seen = HashSet::new();
+        let mut task_names = Vec::new();
+
+        while let Some(row) = rows.next().context("Failed to read recent task name row")? {
+            let name = row.get::<_, String>(0)?.trim().to_string();
+            if name.is_empty() || name == "New Task" || !seen.insert(name.clone()) {
+                continue;
+            }
+
+            task_names.push(name);
+        }
+
+        Ok(task_names)
     }
 
     fn count_legacy_json_files(data_dir: &Path) -> Result<(u64, u64)> {
@@ -1304,6 +1349,47 @@ mod tests {
 
         let dates = storage.list_dates_with_records().unwrap();
         assert_eq!(dates, vec![date1, date3]);
+    }
+
+    #[test]
+    fn test_recent_task_names_are_recent_unique_and_exclude_new_task() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::new_with_dir(temp_dir.path().to_path_buf()).unwrap();
+        let today = create_test_date();
+        let yesterday = today.previous_day().unwrap();
+        let three_days_ago = yesterday.previous_day().unwrap().previous_day().unwrap();
+        let four_days_ago = three_days_ago.previous_day().unwrap();
+
+        let mut today_data = DayData::new(today);
+        today_data.add_record(create_test_record(1, "Today Task"));
+        today_data.add_record(create_test_record(2, "Repeat Task"));
+        today_data.add_record(create_test_record(3, "New Task"));
+        storage.save(&today_data).unwrap();
+
+        let mut yesterday_data = DayData::new(yesterday);
+        yesterday_data.add_record(create_test_record(1, "Yesterday Task"));
+        yesterday_data.add_record(create_test_record(2, "Repeat Task"));
+        storage.save(&yesterday_data).unwrap();
+
+        let mut three_days_ago_data = DayData::new(three_days_ago);
+        three_days_ago_data.add_record(create_test_record(1, "Three Days Ago Task"));
+        storage.save(&three_days_ago_data).unwrap();
+
+        let mut four_days_ago_data = DayData::new(four_days_ago);
+        four_days_ago_data.add_record(create_test_record(1, "Too Old Task"));
+        storage.save(&four_days_ago_data).unwrap();
+
+        let task_names = storage.recent_task_names(today, 3).unwrap();
+
+        assert_eq!(
+            task_names,
+            vec![
+                "Repeat Task",
+                "Today Task",
+                "Yesterday Task",
+                "Three Days Ago Task"
+            ]
+        );
     }
 
     #[test]

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -664,7 +664,7 @@ impl AppState {
             })
             .collect();
 
-        results.sort_by(|a, b| b.1.cmp(&a.1));
+        results.sort_by_key(|(_, score, _)| std::cmp::Reverse(*score));
         results
     }
 

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -72,6 +72,7 @@ pub struct AppState {
     pub theme: Theme,
     pub last_error_message: Option<String>,
     pub task_picker_selected: usize,
+    pub task_picker_tasks: Vec<String>,
     pub active_timer: Option<TimerState>,
     pub last_file_modified: Option<std::time::SystemTime>,
     history: History,
@@ -193,6 +194,7 @@ impl AppState {
             theme,
             last_error_message: None,
             task_picker_selected: 0,
+            task_picker_tasks: Vec::new(),
             active_timer: None,
             last_file_modified: None,
             history: History::new(),
@@ -294,14 +296,14 @@ impl AppState {
         }
     }
 
-    pub fn change_task_name(&mut self) {
+    pub fn change_task_name(&mut self, task_names: Vec<String>) {
         if matches!(self.edit_field, EditField::Name) && self.get_selected_record().is_some() {
             // Check if there are any existing tasks to pick from
-            let task_names = self.get_unique_task_names();
             if !task_names.is_empty() {
                 // Open task picker if tasks exist
                 self.input_buffer.clear();
                 self.task_picker_selected = 0;
+                self.task_picker_tasks = task_names;
                 self.mode = AppMode::TaskPicker;
             } else {
                 // Go directly to edit mode if no tasks exist
@@ -880,10 +882,15 @@ impl AppState {
     pub fn close_task_picker(&mut self) {
         // Cancel and return to Browse mode
         self.input_buffer.clear();
+        self.task_picker_tasks.clear();
         self.mode = AppMode::Browse;
     }
 
     pub fn get_unique_task_names(&self) -> Vec<String> {
+        if !self.task_picker_tasks.is_empty() {
+            return self.task_picker_tasks.clone();
+        }
+
         use std::collections::HashSet;
 
         let mut seen = HashSet::new();
@@ -949,6 +956,7 @@ impl AppState {
         }
 
         self.input_buffer.clear();
+        self.task_picker_tasks.clear();
         self.mode = AppMode::Browse;
     }
 


### PR DESCRIPTION
## Summary
- Load task picker suggestions from the selected day plus the previous 3 days.
- Sort suggestions by recent usage, de-duplicate names, and exclude the default `New Task` placeholder.
- Add storage coverage for recent task ordering, uniqueness, and cutoff behavior.

## Verification
- `nix develop --command cargo fmt --check`
- `nix develop --command cargo clippy`
- `nix develop --command cargo test`

Fixes #69